### PR TITLE
Refactor: Make logging the default callback behavior

### DIFF
--- a/lib/sidekiq/memory_logger.rb
+++ b/lib/sidekiq/memory_logger.rb
@@ -13,7 +13,7 @@ module Sidekiq
 
       def initialize
         @logger = default_logger
-        @callback = nil
+        @callback = default_callback
       end
 
       private
@@ -24,6 +24,12 @@ module Sidekiq
         else
           require "logger"
           ::Logger.new($stdout)
+        end
+      end
+
+      def default_callback
+        ->(job_class, queue, memory_diff_mb) do
+          @logger.info("Job #{job_class} on queue #{queue} used #{memory_diff_mb} MB")
         end
       end
     end
@@ -54,14 +60,10 @@ module Sidekiq
           end_mem = GetProcessMem.new.mb
           memory_diff = end_mem - start_mem
 
-          if @config.callback
-            begin
-              @config.callback.call(job["class"], queue, memory_diff)
-            rescue => e
-              @config.logger.error("Sidekiq memory logger callback failed: #{e.message}")
-            end
-          else
-            @config.logger.info("Job #{job["class"]} on queue #{queue} used #{memory_diff} MB")
+          begin
+            @config.callback.call(job["class"], queue, memory_diff)
+          rescue => e
+            @config.logger.error("Sidekiq memory logger callback failed: #{e.message}")
           end
         end
       end

--- a/test/sidekiq/memory_logger/configuration_test.rb
+++ b/test/sidekiq/memory_logger/configuration_test.rb
@@ -10,7 +10,8 @@ class TestSidekiqMemoryLoggerConfiguration < Minitest::Test
   def test_default_values
     refute_nil @config.logger
     assert_kind_of Logger, @config.logger
-    assert_nil @config.callback
+    refute_nil @config.callback
+    assert_kind_of Proc, @config.callback
   end
 
   def test_setting_logger

--- a/test/sidekiq/memory_logger/middleware_test.rb
+++ b/test/sidekiq/memory_logger/middleware_test.rb
@@ -33,12 +33,14 @@ class TestSidekiqMemoryLoggerMiddleware < Minitest::Test
     assert_kind_of Float, memory_diff
   end
 
-  def test_middleware_logs_when_no_callback
+  def test_middleware_logs_with_default_callback
     log_output = StringIO.new
     test_logger = Logger.new(log_output)
 
     Sidekiq::MemoryLogger.configure do |config|
       config.logger = test_logger
+      # Reset to default callback (which logs)
+      config.callback = config.send(:default_callback)
     end
 
     # Create new middleware after configuration change


### PR DESCRIPTION
## Summary
- Restructured code to make `logger.info` call the default callback implementation
- Removed conditional branching in middleware for cleaner, more consistent code
- Updated tests and documentation to reflect the new behavior

## Changes
- Added `default_callback` method to Configuration that returns a lambda for logging memory usage
- Simplified middleware by removing the if/else logic - now always calls the callback
- Updated configuration test to expect a default callback instead of nil
- Modified middleware test to work with the default callback behavior
- Updated README to clarify that logging is the default behavior and how to customize it

## Test plan
- [x] Run `bundle exec rake` - all tests pass
- [x] Verify default logging behavior works as expected
- [x] Verify custom callbacks can still be configured
- [x] Ensure error handling for callback failures still works

🤖 Generated with [Claude Code](https://claude.ai/code)