### PR TITLE
Add queue filtering configuration to middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ Sidekiq::MemoryLogger.configure do |config|
   # Change the logger (default uses Rails.logger if available, otherwise stdout)
   config.logger = MyCustomLogger.new
   
+  # Specify which queues to monitor (empty array monitors all queues)
+  config.queues = ["critical", "mailers"]  # Only monitor these queues
+  # config.queues = []  # Monitor all queues (default)
+  
   # Replace the default logging callback with custom behavior
   # The callback now receives job arguments as the 4th parameter
   config.callback = ->(job_class, queue, memory_diff_mb, args) do


### PR DESCRIPTION
## Summary
- Add `queues` configuration option to allow filtering which queues the middleware monitors
- When empty array (default), middleware processes all queues
- When populated, middleware only processes jobs from specified queues
- Middleware completely skips processing (no memory measurement) for non-matching queues

## Implementation Details
- Added `queues` attribute to `Configuration` class with empty array default
- Modified middleware `call` method to return early if queue not in configured list
- Added private `should_skip_queue?` method to encapsulate filtering logic
- Updated README with configuration examples

## Test Plan
- [x] Test middleware skips queues not in configuration list
- [x] Test middleware processes queues that are in configuration list  
- [x] Test middleware processes all queues when configuration is empty (default behavior)
- [x] All existing tests continue to pass
- [x] Code passes linting and style checks

🤖 Generated with [Claude Code](https://claude.ai/code)