### PR TITLE
Fix CI test failures: variable name bug in middleware

### DIFF
--- a/lib/sidekiq/memory_logger.rb
+++ b/lib/sidekiq/memory_logger.rb
@@ -75,8 +75,8 @@ module Sidekiq
       private
 
       def should_skip_queue?(queue)
-        return false if @config.queues.empty?
-        !@config.queues.include?(queue)
+        return false if @memory_logger_config.queues.empty?
+        !@memory_logger_config.queues.include?(queue)
       end
     end
   end


### PR DESCRIPTION
## Summary
- Fixed NoMethodError in middleware where `@config.queues` was referenced instead of `@memory_logger_config.queues`
- All tests now pass successfully

## Test plan
- [x] Run `bundle exec rake` - all tests pass
- [x] Verified fix resolves the specific CI failure from Ruby 3.0 build

🤖 Generated with [Claude Code](https://claude.ai/code)