### PR TITLE
Change default log message format to structured format

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Memory measurement is handled by the [get_process_mem](https://github.com/zomboc
 
 By default, this gem just logs at `info` level for every job:
 ```
-Job MyJob on queue default used 15.2 MB
+[MemoryLogger] job=MyJob queue=default memory_mb=15.2
 ```
 
 We recommend using logs as the basis for your investigation, but you can also parse this log and create a metric (e.g. with Sumo or Datadog) or change the callback we use (see Configuration below) to create metrics.
@@ -103,7 +103,7 @@ Sidekiq::MemoryLogger.configure do |config|
   
   # The default callback logs memory usage like this:
   # config.callback = ->(job_class, queue, memory_diff_mb, args) do
-  #   config.logger.info("Job #{job_class} on queue #{queue} used #{memory_diff_mb} MB")
+  #   config.logger.info("[MemoryLogger] job=#{job_class} queue=#{queue} memory_mb=#{memory_diff_mb}")
   # end
   
   # If you want custom metrics AND logging, include both in your callback:

--- a/lib/sidekiq/memory_logger.rb
+++ b/lib/sidekiq/memory_logger.rb
@@ -31,7 +31,7 @@ module Sidekiq
 
       def default_callback
         ->(job_class, queue, memory_diff_mb, args) do
-          @logger.info("Job #{job_class} on queue #{queue} used #{memory_diff_mb} MB")
+          @logger.info("[MemoryLogger] job=#{job_class} queue=#{queue} memory_mb=#{memory_diff_mb}")
         end
       end
     end

--- a/test/sidekiq/memory_logger/middleware_test.rb
+++ b/test/sidekiq/memory_logger/middleware_test.rb
@@ -38,8 +38,7 @@ class TestSidekiqMemoryLoggerMiddleware < Minitest::Test
     middleware.call(nil, @job, @queue) { sleep 0.01 }
 
     log_content = log_output.string
-    assert_includes log_content, "Job TestJob on queue test_queue used"
-    assert_includes log_content, "MB"
+    assert_includes log_content, "[MemoryLogger] job=TestJob queue=test_queue memory_mb="
   end
 
   def test_middleware_handles_exceptions


### PR DESCRIPTION
## Summary
- Changed default log message from `Job MyJob on queue default used 15.2 MB` to `[MemoryLogger] job=MyJob queue=default memory_mb=15.2`
- Updated tests to expect the new format
- Updated README documentation with new format examples

## Benefits
- More structured and parseable log format
- Consistent with modern logging practices
- Easier to parse for log aggregation tools
- Clear identification with `[MemoryLogger]` prefix

## Test plan
- [x] All existing tests pass with updated expectations
- [x] Verified new log format is generated correctly
- [x] Updated documentation reflects new format

🤖 Generated with [Claude Code](https://claude.ai/code)