### PR TITLE
Add object allocation tracking to memory logger middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Sidekiq::MemoryLogger.configure do |config|
   # config.queues = []  # Monitor all queues (default)
   
   # Replace the default logging callback with custom behavior
-  # The callback now receives job arguments as the 4th parameter
-  config.callback = ->(job_class, queue, memory_diff_mb, args) do
+  # The callback now receives job arguments as the 5th parameter
+  config.callback = ->(job_class, queue, memory_diff_mb, objects_diff, args) do
     # Example: Extract company_id from job arguments
     # Assuming your job is called like: ProcessCompanyDataJob.perform_async(company_id, other_params)
     company_id = args&.first
@@ -100,12 +100,12 @@ Sidekiq::MemoryLogger.configure do |config|
   end
   
   # The default callback logs memory usage like this:
-  # config.callback = ->(job_class, queue, memory_diff_mb, args) do
+  # config.callback = ->(job_class, queue, memory_diff_mb, objects_diff, args) do
   #   config.logger.info("[MemoryLogger] job=#{job_class} queue=#{queue} memory_mb=#{memory_diff_mb}")
   # end
   
   # If you want custom metrics AND logging, include both in your callback:
-  config.callback = ->(job_class, queue, memory_diff_mb, args) do
+  config.callback = ->(job_class, queue, memory_diff_mb, objects_diff, args) do
     # Your custom metrics collection
     StatsD.histogram('sidekiq.memory_usage', memory_diff_mb, tags: {
       job_class: job_class, 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Have you ever seen massive memory increases in your Sidekiq workers? Well, this 
 
 ## How it works
 
-Memory measurement is handled by the [get_process_mem](https://github.com/zombocom/get_process_mem) gem, which works across all platforms (Windows, macOS, Linux) and both inside and outside of containers.
+Memory measurement is handled by the [get_process_mem](https://github.com/zombocom/get_process_mem) gem, which works across all platforms (Windows, macOS, Linux) and both inside and outside of containers. Object allocation tracking uses Ruby's built-in `GC.stat[:total_allocated_objects]`.
 
 By default, this gem just logs at `info` level for every job:
 ```
-[MemoryLogger] job=MyJob queue=default memory_mb=15.2
+[MemoryLogger] job=MyJob queue=default memory_mb=15.2 objects=12345
 ```
 
 You can also parse this log and create a metric (e.g. with Sumo or Datadog) or change the callback we use (see Configuration below) to create metrics.

--- a/bin/sidekiqload
+++ b/bin/sidekiqload
@@ -104,7 +104,7 @@ class Loader
         $memory_stats = {jobs_tracked: 0}
         
         Sidekiq::MemoryLogger.configure do |memory_config|
-          memory_config.callback = ->(job_class, queue, memory_diff, args) do
+          memory_config.callback = ->(job_class, queue, memory_diff, objects_diff, args) do
             $memory_stats[:jobs_tracked] += 1
           end
         end


### PR DESCRIPTION
## Summary
- Added object allocation tracking using `GC.stat[:total_allocated_objects]`
- Callback signature now includes `objects_diff` as 4th parameter (breaking change)
- Default log format now includes `objects=12345` alongside memory usage
- Updated all tests to handle new callback signature
- Updated README documentation

## Test plan
- [x] All existing tests pass with updated callback signatures
- [x] Default callback logs both memory and object allocation
- [x] Custom callbacks receive objects_diff parameter correctly
- [x] Middleware tracks objects before and after job execution
- [x] README documentation updated with examples

🤖 Generated with [Claude Code](https://claude.ai/code)