### PR TITLE
Compatibility with old sidekiq versions

### DIFF
--- a/lib/sidekiq/memory_logger.rb
+++ b/lib/sidekiq/memory_logger.rb
@@ -47,8 +47,6 @@ module Sidekiq
     end
 
     class Middleware
-      include Sidekiq::ServerMiddleware
-
       def initialize(config = nil)
         @memory_logger_config = config || MemoryLogger.configuration
       end


### PR DESCRIPTION
The `ServerMiddleware` module used in the current implementation was introduced "only" in sidekiq version 6, thus old versions of sidekiq were not compatible with the middleware.

This PR makes the middleware compatible with old sidekiq versions by just not including the module. This is fine because no functionality provided by the module is used in the middleware.

I considered the make the inclusion conditional but then decided to drop it since no functionality is used. If you like the conditional inclusion approach better then let me know!

```ruby
class Middleware
  include Sidekiq::ServerMiddleware if defined?(Sidekiq::Middleware)
  ...
end
```